### PR TITLE
Bump fs-promise to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "colors": "1.0.3",
     "commander": "2.4.0",
-    "fs-promise": "0.3.0",
+    "fs-promise": "0.3.1",
     "fs-extra": "0.13.0",
     "jpm-core": "0.0.4",
     "jetpack-id": "0.0.4",


### PR DESCRIPTION
Version 0.3.0 was causing jpm to fail mysteriously on Node v0.11.13, probably because [13 has a problem with native promises](https://github.com/joyent/node/issues/7714).

0.3.1 makes it use a newer version of any-promise, which apparently changed the way native promises are used (https://github.com/kevinbeaty/any-promise/commit/85b3b365fdde37117b65eb8a7c7daaebbca11a93).

This is only an issue on Node v0.11.13, but bumping it doesn't harm I suppose.