### PR TITLE
binary path resolution: cleanup + Linux fix (use `which`)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,11 @@ var Winreg = require('winreg');
 var when = require("when");
 var parse = require("mozilla-toolkit-versioning").parse;
 var compare = require("mozilla-version-comparator");
+var nodefn = require("when/node");
+var which = nodefn.lift(require("which"));
+
 var AOM_SUPPORT_VERSION = require("./settings").AOM_SUPPORT_VERSION;
+var APP_NAMES = ["firefox", "beta", "nightly", "aurora"];
 
 colors.setTheme({
   verbose: "cyan",
@@ -101,12 +105,15 @@ function getManifest () {
     return resolve(manifest);
   })
 }
+
 exports.getManifest = getManifest;
 
 /**
- * Takes a path to a binary file (like `/Applications/FirefoxNightly.app`)
- * and based on OS, resolves to the actual binary file. Accepts an optional
- * `platform` and `arch` parameter for testing.
+ * Takes an app name (e.g. `firefox` or `beta`) or a path to a
+ * binary file (e.g. `/Applications/FirefoxNightly.app`), and, based
+ * on the OS, resolves the absolute path to the corresponding binary
+ * file (or its shell-script wrapper). Accepts optional `platform`
+ * and `arch` parameters for testing.
  *
  * @param {String} binaryPath
  * @param {String} (platform)
@@ -115,100 +122,110 @@ exports.getManifest = getManifest;
  */
 
 function normalizeBinary (binaryPath, platform, arch) {
-  return when.promise(function(resolve, reject) {
+  return when.promise(function (resolve, reject) {
+    binaryPath = binaryPath || process.env.JPM_FIREFOX_BINARY || "firefox";
     platform = platform || os.platform();
     arch = arch || os.arch();
-    binaryPath = binaryPath || process.env.JPM_FIREFOX_BINARY || "firefox";
 
-    arch = /64/.test(arch) ? "(64)" : "";
-    platform = /darwin/i.test(platform) ? "osx" :
-               /win/i.test(platform) ? "windows" + arch :
-               /linux/i.test(platform) ? "linux" + arch :
-               platform;
-
+    var platformId = /darwin/i.test(platform) ? "osx" :
+                     /win/i.test(platform) ? "windows" :
+                     /linux/i.test(platform) ? "linux" :
+                     platform;
+    var archId = /64/.test(arch) ? "(64)" : arch;
     var app = binaryPath.toLowerCase();
-    binaryPath = normalizeBinary.paths[app + " on " + platform] ||
-                 normalizeBinary.paths[app + " on " + platform + arch] ||
-                 binaryPath;
 
-    var isAppPath = platform === "osx" && path.extname(binaryPath) === ".app";
+    function isAppName (name) {
+      return ~APP_NAMES.indexOf(name);
+    }
 
-    // On OSX, if given the app path, resolve to the actual binary
-    binaryPath = isAppPath ? path.join(binaryPath, "Contents/MacOS/firefox-bin") :
-                 binaryPath;
-    var channelNames = ["firefox", "beta", "nightly", "aurora"];
-    // not Windows or binary path given
-    if (platform.indexOf("windows") === -1 || channelNames.indexOf(app) === -1) {
+    if (isAppName(app)) {
+      binaryPath = normalizeBinary.paths[app + " on " + platformId + archId] ||
+                   normalizeBinary.paths[app + " on " + platformId] ||
+                   binaryPath;
+      app = binaryPath.toLowerCase();
+    }
+
+    if (isAppName(app)) {
+      if (platformId === "windows") {
+        return normalizeWindowsBinary(resolve, reject, archId, app);
+      } else { // Linux &c.
+        return which(app).then(resolve, reject);
+      }
+    } else { // binary path e.g. /usr/bin/firefox
+      // On OS X, if given the app path, resolve to the actual binary
+      if ((platformId === "osx") && (path.extname(binaryPath) === ".app")) {
+        binaryPath = path.join(binaryPath, "Contents/MacOS/firefox-bin");
+      }
       return resolve(binaryPath);
     }
-    // Windows binary finding
-    var appName = "Mozilla Firefox";
-    switch(app) {
-      case "beta":
-        // the default path in the beta installer is the same as the stable one
-        appName = "Mozilla Firefox";
-        break;
-      case "aurora":
-        appName = "Aurora";
-        break;
-      case "nightly":
-        appName = "Nightly";
-        break;
-      default:
-        break;
-    }
-    // this is used when reading the registry goes wrong.
-    function fallBack () {
-      var programFilesVar = "ProgramFiles";
-      if (arch === "(64)") {
-        programFilesVar = "ProgramFiles(x86)";
-      }
-      resolve(path.join(process.env[programFilesVar], appName, "firefox.exe"));
-    }
-
-    var rootKey = '\\Software\\Mozilla\\';
-    if (arch === "(64)") {
-      rootKey = '\\Software\\Wow6432Node\\Mozilla';
-    }
-    rootKey = path.join(rootKey, appName);
-
-    return when.promise(function(resolve, reject) {
-      var versionKey = new Winreg({
-        hive: Winreg.HKLM,
-        key: rootKey
-      });
-      versionKey.get("CurrentVersion", function(err, key) {
-        return (err) ? reject() : resolve(key.value);
-      });
-    }).then(function(version) {
-      var mainKey = new Winreg({
-        hive: Winreg.HKLM,
-        key: path.join(rootKey, version, "Main")
-      });
-      mainKey.get("PathToExe", function(err, key) {
-        if (err) {
-          fallBack();
-          return;
-        }
-        resolve(key.value);
-      });
-    }, fallBack);
   });
 }
+
+// resolve the binary path on Windows
+function normalizeWindowsBinary (resolve, reject, arch, app) {
+  var appName = "Mozilla Firefox";
+  var win64 = arch === "(64)";
+
+  switch (app) {
+    case "beta":
+      // the default path in the beta installer is the same as the stable one
+      appName = "Mozilla Firefox";
+      break;
+    case "aurora":
+      appName = "Aurora";
+      break;
+    case "nightly":
+      appName = "Nightly";
+      break;
+    default:
+      break;
+  }
+
+  // this is used when reading the registry goes wrong.
+  function fallBack () {
+    var programFilesVar = "ProgramFiles";
+    if (win64) {
+      programFilesVar = "ProgramFiles(x86)";
+    }
+    resolve(path.join(process.env[programFilesVar], appName, "firefox.exe"));
+  }
+
+  var rootKey = '\\Software\\Mozilla\\';
+
+  if (win64) {
+    rootKey = '\\Software\\Wow6432Node\\Mozilla';
+  }
+
+  rootKey = path.join(rootKey, appName);
+
+  return when.promise(function (resolve, reject) {
+    var versionKey = new Winreg({
+      hive: Winreg.HKLM,
+      key: rootKey
+    });
+    versionKey.get("CurrentVersion", function (err, key) {
+      return (err) ? reject() : resolve(key.value);
+    });
+  }).then(function (version) {
+    var mainKey = new Winreg({
+      hive: Winreg.HKLM,
+      key: path.join(rootKey, version, "Main")
+    });
+    mainKey.get("PathToExe", function (err, key) {
+      if (err) {
+        fallBack();
+        return;
+      }
+      resolve(key.value);
+    });
+  }, fallBack);
+}
+
 normalizeBinary.paths = {
   "firefox on osx": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
-  "beta on osx": "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin",
-  "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
-  "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
-
-  "firefox on linux": "/usr/lib/firefox",
-  "beta on linux": "/usr/lib/firefox-beta",
-  "aurora on linux": "/usr/lib/firefox-aurora",
-  "nightly on linux": "/usr/lib/firefox-nightly",
-
-  "firefox on linux(64)": "/usr/lib64/firefox",
-  "beta on linux(64)": "/usr/lib64/firefox-beta",
-  "aurora on linux(64)": "/usr/lib64/firefox-aurora",
-  "nightly on linux(64)" : "/usr/lib64/firefox-nightly"
+  "beta on osx":    "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin",
+  "aurora on osx":  "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
+  "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin"
 };
+
 exports.normalizeBinary = normalizeBinary;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jetpack-validation": "0.0.4",
     "winreg": "0.0.12",
     "when": "3.6.4",
+    "which": "^1.0.8",
     "zip-dir": "0.2.1"
   },
   "devDependencies": {

--- a/test/unit/test.utils.js
+++ b/test/unit/test.utils.js
@@ -107,12 +107,17 @@ describe("lib/utils", function () {
     delete process.env.JPM_FIREFOX_BINARY;
     var args = 0;
     var expected = 1;
+    var binary = sandbox.require("../../lib/utils", {
+      requires: {"which": function(name, callback) {
+        callback(null, "/path/to/" + name);
+      }}
+    }).normalizeBinary;
 
     var promises = [
       [[null, "darwin", "x86"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
       [[null, "darwin", "x86_64"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
-      [[null, "linux", "x86"], "/usr/lib/firefox"],
-      [[null, "linux", "x86_64"], "/usr/lib64/firefox"]
+      [[null, "linux", "x86"], "/path/to/firefox"],
+      [[null, "linux", "x86_64"], "/path/to/firefox"]
     ].map(function(fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {
@@ -188,27 +193,32 @@ describe("lib/utils", function () {
   it("normalizeBinary() normalizes special names like: firefox, nightly, etc...(non-Windows)", function(done) {
     var args = 0;
     var expected = 1;
+    var binary = sandbox.require("../../lib/utils", {
+      requires: {"which": function(name, callback) {
+        callback(null, "/path/to/" + name);
+      }}
+    }).normalizeBinary;
 
     var promises = [
       [["firefox", "darwin", "x86"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
       [["firefox", "darwin", "x86_64"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
-      [["firefox", "linux", "x86"], "/usr/lib/firefox"],
-      [["firefox", "linux", "x86_64"], "/usr/lib64/firefox"],
+      [["firefox", "linux", "x86"], "/path/to/firefox"],
+      [["firefox", "linux", "x86_64"], "/path/to/firefox"],
 
       [["beta", "darwin", "x86"], "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin"],
       [["beta", "darwin", "x86_64"], "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin"],
-      [["beta", "linux", "x86"], "/usr/lib/firefox-beta"],
-      [["beta", "linux", "x86_64"], "/usr/lib64/firefox-beta"],
+      [["beta", "linux", "x86"], "/path/to/beta"],
+      [["beta", "linux", "x86_64"], "/path/to/beta"],
 
       [["aurora", "darwin", "x86"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin"],
       [["aurora", "darwin", "x86_64"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin"],
-      [["aurora", "linux", "x86"], "/usr/lib/firefox-aurora"],
-      [["aurora", "linux", "x86_64"], "/usr/lib64/firefox-aurora"],
+      [["aurora", "linux", "x86"], "/path/to/aurora"],
+      [["aurora", "linux", "x86_64"], "/path/to/aurora"],
 
       [["nightly", "darwin", "x86"], "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin"],
       [["nightly", "darwin", "x86_64"], "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin"],
-      [["nightly", "linux", "x86"], "/usr/lib/firefox-nightly"],
-      [["nightly", "linux", "x86_64"], "/usr/lib64/firefox-nightly"]
+      [["nightly", "linux", "x86"], "/path/to/nightly"],
+      [["nightly", "linux", "x86_64"], "/path/to/nightly"]
     ].map(function(fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {


### PR DESCRIPTION
Another attempt at a fix (+ cleanup) for #178. Uses [`which`](https://github.com/isaacs/node-which) to resolve the path on Linux &c.

The tests pass for all platforms, but it has only been tested manually on Linux (Ubuntu 14.04).