### PR TITLE
add name option to jpm init

### DIFF
--- a/bin/jpm
+++ b/bin/jpm
@@ -57,10 +57,10 @@ program
   }));
 
 program
-  .command("init")
+  .command("init [name]")
   .description("Series of prompts to create a package.json for a new addon")
-  .action(function () {
-    init().then(process.exit);
+  .action(function (name) {
+    init({ name: name }).then(process.exit);
   });
 
 program

--- a/lib/init-input.js
+++ b/lib/init-input.js
@@ -9,7 +9,7 @@ var semver = require("semver");
 
 module.exports = {
   "title": prompt("title", "My Jetpack Addon", identity),
-  "name": prompt("name", path.basename(process.cwd()), sanitizeName),
+  "name": prompt("name", name || path.basename(process.cwd()), sanitizeName),
   "version": prompt("version", "0.0.1", sanitizeVersion),
   "description": prompt("description", "", identity),
   "main": prompt("entry point", "index.js", identity),

--- a/lib/init.js
+++ b/lib/init.js
@@ -18,17 +18,24 @@ var SOURCE_TEST = join(__dirname, "../data/test-index.js");
 function init (options) {
   var root = process.cwd();
 
-  return createManifest(root)
-    .then(createFiles.bind(null, root))
-    .catch(console.error);
+  if (options.name) {
+    root = join(root, options.name);
+  }
+
+  return fs.exists(root).then(function (exists) {
+    return (exists) ? null : fs.mkdir(root);;
+  })
+  .then(createManifest.bind(null, root, options))
+  .then(createFiles.bind(null, root))
+  .catch(console.error);
 }
 module.exports = init;
 
-function createManifest (root) {
+function createManifest (root, options) {
   return when.promise(function(resolve, reject) {
     var packagePath = join(root, "package.json");
 
-    promzard(initInput, {}, function (err, data) {
+    promzard(initInput, { name: options.name }, function (err, data) {
       if (err) {
         return reject(err);
       }

--- a/test/functional/test.init.js
+++ b/test/functional/test.init.js
@@ -37,6 +37,18 @@ describe("jpm init", function () {
     });
   });
 
+  it("creates an addon with a custom name in a new directory", function (done) {
+    process.chdir(utils.tmpOutputDir);
+    var responses = generateResponses();
+
+    var proc = respond(exec("init my-custom-name"), responses);
+    proc.on("close", function () {
+      var manifest = JSON.parse(fs.readFileSync(path.join(utils.tmpOutputDir, "my-custom-name", "package.json"), "utf-8"));
+      expect(manifest.name).to.be.equal("my-custom-name");
+      done();
+    });
+  });
+
   it("creates package.json with custom entries", function (done) {
     process.chdir(utils.tmpOutputDir);
     var responses = [


### PR DESCRIPTION
This enables the jpm user to call `jpm init my-addon-name` and have it initialize in a new directory called "my-addon-name", also the name in the prompt wizard default is set to that name.

cfx already does this, for instance.

Calls to `jpm init` without a name will still initialize in the same directory the user is currently in.