### PR TITLE
Upgrade zip-dir to 1.0.0, which fixes io.js support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash": "2.4.1",
     "when": "2.8.0",
     "underscore": "1.6.0",
-    "zip-dir": "0.2.1",
+    "zip-dir": "1.0.0",
     "tmp": "0.0.23",
     "promzard": "0.2.1",
     "read": "1.0.5",


### PR DESCRIPTION
Fixes #243 