### PR TITLE
Convert relative icon paths to resource urls

### DIFF
--- a/lib/rdf.js
+++ b/lib/rdf.js
@@ -7,6 +7,8 @@ var jsontoxml = require("jsontoxml");
 var getID = require("jetpack-id");
 var parse = require("mozilla-toolkit-versioning").parse;
 var GUIDS = require("./settings").ids;
+var utils = require("./utils");
+var console = require("./utils").console;
 var MIN_VERSION = require("./settings").MIN_VERSION;
 var MAX_VERSION = require("./settings").MAX_VERSION;
 
@@ -48,6 +50,32 @@ function createRDF (manifest) {
     "em:icon64URL": manifest.icon64 || "icon64.png"
   };
 
+  /* Temporary workaround for custom icon paths not being resolved correctly
+   * Converts icon paths to resource:// urls, which has several drawbacks
+   * TODO remove this once it's fixed in Firefox
+   */
+
+  var normalizedID = utils.normalizeID(jetpackMeta["em:id"]);
+
+  if (manifest.icon && manifest.icon !== "icon.png") {
+    console.warn("Consider using icon.png instead of a custom iconURL. \
+See https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#iconURL");
+
+    if (manifest.icon.indexOf("://") === -1) {
+      jetpackMeta["em:iconURL"]= "resource://" + normalizedID + "/" + manifest.icon;
+    }
+  }
+
+  if (manifest.icon64 && manifest.icon64 !== "icon64.png") {
+    console.warn("Consider using icon64.png instead of a custom icon64URL. \
+See https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#icon64URL");
+
+    if (manifest.icon64.indexOf("://") === -1) {
+      jetpackMeta["em:icon64URL"]= "resource://" + normalizedID + "/" + manifest.icon64;
+    }
+  }
+
+
   if (manifest.homepage) {
     jetpackMeta["em:homepageURL"] = manifest.homepage;
   }
@@ -71,7 +99,7 @@ function createRDF (manifest) {
   if (manifest.developers) {
     manifest.developers.forEach(function(dev) {
       description.children.push({ "em:developer": dev });
-    })
+    });
   }
 
   var engines = Object.keys(manifest.engines || {});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,27 @@ colors.setTheme({
 });
 
 /**
+ * Takes an add-on ID and normalizes it to a domain name so that
+ * it can be mapped to resource://domain/
+ *
+ * @param {String} id to normalize
+ * @return {String} normalized id
+ */
+
+var UUID_PATTERN = /^\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\}$/;
+function normalizeID (id) {
+  if (id) {
+    return id.lastIndexOf("@") === 0 ? id.substr(1).toLowerCase() :
+           id.toLowerCase().
+              replace(/@/g, "-at-").
+              replace(/\./g, "-dot-").
+              replace(UUID_PATTERN, "$1");
+  }
+  return "";
+}
+exports.normalizeID = normalizeID;
+
+/**
  * Takes a `manifest` object and determines whether or not
  * AOM is supported by all platforms that the addon supports.
  *

--- a/test/unit/test.rdf.js
+++ b/test/unit/test.rdf.js
@@ -93,14 +93,32 @@ describe("lib/rdf", function () {
       expect(xml.indexOf("Marie Curie &lt;mc@espci.fr&gt;")).to.be.not.equal(-1);
     });
 
-    it("iconURL uses `icon`", function () {
-      var xml = setupRDF({ icon: "megaman.png" });
-      expect(getData(xml, "em:iconURL")).to.be.equal("megaman.png");
+    it("iconURL transforms `icon` to a resource url", function () {
+      var xml = setupRDF({ id: "icon@jetpack", icon: "megaman.png" });
+      expect(getData(xml, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
     });
 
-    it("icon64URL uses `icon64`", function () {
-      var xml = setupRDF({ icon64: "megaman.png" });
-      expect(getData(xml, "em:icon64URL")).to.be.equal("megaman.png");
+    it("icon64URL transforms `icon64` to a resource url", function () {
+      var xml = setupRDF({ id: "icon@jetpack", icon64: "megaman.png" });
+      expect(getData(xml, "em:icon64URL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
+    });
+
+    it("iconURL uses a url without modifying it", function () {
+      var xml1 = setupRDF({ id: "icon@jetpack", icon: "http://mozilla.org/icon.png" });
+      expect(getData(xml1, "em:iconURL")).to.be.equal("http://mozilla.org/icon.png");
+      var xml2 = setupRDF({ id: "icon@jetpack", icon: "chrome://icon-at-jetpack/icon.png" });
+      expect(getData(xml2, "em:iconURL")).to.be.equal("chrome://icon-at-jetpack/icon.png");
+      var xml3 = setupRDF({ id: "icon@jetpack", icon: "resource://icon-at-jetpack/megaman.png" });
+      expect(getData(xml3, "em:iconURL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
+    });
+
+    it("icon64URL uses a url without modifying it", function () {
+      var xml1 = setupRDF({ id: "icon@jetpack", icon64: "http://mozilla.org/icon.png" });
+      expect(getData(xml1, "em:icon64URL")).to.be.equal("http://mozilla.org/icon.png");
+      var xml2 = setupRDF({ id: "icon@jetpack", icon64: "chrome://icon-at-jetpack/icon.png" });
+      expect(getData(xml2, "em:icon64URL")).to.be.equal("chrome://icon-at-jetpack/icon.png");
+      var xml3 = setupRDF({ id: "icon@jetpack", icon64: "resource://icon-at-jetpack/megaman.png" });
+      expect(getData(xml3, "em:icon64URL")).to.be.equal("resource://icon-at-jetpack/megaman.png");
     });
 
     it("updateURL uses `updateURL`", function () {


### PR DESCRIPTION
This is a temporary hack to workaround #197 until the issue is resolved and landed in Firefox. 

Converting icon paths to resource urls has several drawbacks, such as not displaying when the add-on is turned off and the possibility of resource:// being changed at some point in the future. Hence the warning.

The code for `normalizeID` is mostly taken from https://github.com/mozilla/addon-sdk/blob/12391f89c0fc82fbd4683c87df2aee8dfc58772d/lib/sdk/addon/bootstrap.js#L25