### PR TITLE
Add --no-remote firefox option to create the custom profile in functional tests

### DIFF
--- a/test/functional/test.run.js
+++ b/test/functional/test.run.js
@@ -236,7 +236,7 @@ describe("jpm run", function () {
 
       // find firefox nightly
       normalizeBinary(binary).then(function(path) {
-        var cmd = path + " -CreateProfile \"jpm-test\"";
+        var cmd = path + " --no-remote -CreateProfile \"jpm-test\"";
 
         // Create a profile
         cp.exec(cmd, null, function(err, stdout, stderr) {


### PR DESCRIPTION
A small change to fix the functional test "Passes in a profile name results in -p <path>" (which creates a Firefox profile using the Firefox executable) when a Firefox instance is already running on the system (e.g. locally on a developer laptop).