### PR TITLE
Need en-US locale in MDN URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ npm link
 
 ### Documentation
 
-* [Getting Started Guide](https://developer.mozilla.org/Add-ons/SDK/Tutorials/Getting_Started_%28jpm%29)
-* [Command Line Guide](https://developer.mozilla.org/Add-ons/SDK/Tools/jpm)
-* [Transitioning From CFX](https://developer.mozilla.org/Add-ons/SDK/Tools/cfx_to_jpm)
+* [Getting Started Guide](https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Getting_Started_%28jpm%29)
+* [Command Line Guide](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm)
+* [Transitioning From CFX](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx_to_jpm)
 
 ### Examples
 


### PR DESCRIPTION
When locale doesn't contains the MDN URL, MDN redirects to the localized page which contains a UA's locale, but there are cases have gone to not found page. It avoids this problem by specify `en-US` locale clearly.