### PR TITLE
Update preferences.js

### DIFF
--- a/data/preferences.js
+++ b/data/preferences.js
@@ -39,7 +39,9 @@ exports.DEFAULT_COMMON_PREFS = {
     "extensions.update.url" : "http://localhost/extensions-dummy/updateURL",
     "extensions.blocklist.url" : "http://localhost/extensions-dummy/blocklistURL",
     // Make sure opening about:addons won"t hit the network.
-    "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL"
+    "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL",
+    //Allow unsigned add-ons
+    "xpinstall.signatures.required" : false
 };
 
 exports.DEFAULT_FENNEC_PREFS = {

--- a/data/preferences.js
+++ b/data/preferences.js
@@ -39,7 +39,8 @@ exports.DEFAULT_COMMON_PREFS = {
     "extensions.update.url" : "http://localhost/extensions-dummy/updateURL",
     "extensions.blocklist.url" : "http://localhost/extensions-dummy/blocklistURL",
     // Make sure opening about:addons won"t hit the network.
-    "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL"
+    "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL",
+    "xpinstall.signatures.required" : false
 };
 
 exports.DEFAULT_FENNEC_PREFS = {

--- a/data/preferences.js
+++ b/data/preferences.js
@@ -40,6 +40,7 @@ exports.DEFAULT_COMMON_PREFS = {
     "extensions.blocklist.url" : "http://localhost/extensions-dummy/blocklistURL",
     // Make sure opening about:addons won"t hit the network.
     "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL",
+    //Allow unsigned add-ons
     "xpinstall.signatures.required" : false
 };
 

--- a/data/preferences.js
+++ b/data/preferences.js
@@ -39,9 +39,7 @@ exports.DEFAULT_COMMON_PREFS = {
     "extensions.update.url" : "http://localhost/extensions-dummy/updateURL",
     "extensions.blocklist.url" : "http://localhost/extensions-dummy/blocklistURL",
     // Make sure opening about:addons won"t hit the network.
-    "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL",
-    //Allow unsigned add-ons
-    "xpinstall.signatures.required" : false
+    "extensions.webservice.discoverURL" : "http://localhost/extensions-dummy/discoveryURL"
 };
 
 exports.DEFAULT_FENNEC_PREFS = {


### PR DESCRIPTION
This makes jpm launch firefox with xpinstall.signatures.required : false so unsigned addons can be tested.